### PR TITLE
feat/config: client_max_body_size 디렉티브 파싱 구현

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -1,5 +1,6 @@
 http {
 	server {
+		client_max_body_size 20m;
 	    listen 8080;                        # 80번 포트에서 요청 수신
 	    server_name example.com;          # 도메인 이름
 	    server_name _;          		  # 도메인 이름

--- a/src/config/ConfigParser.cpp
+++ b/src/config/ConfigParser.cpp
@@ -81,7 +81,7 @@ void ConfigParser::parseClientMaxBodySize(
 			"[emerg] Invalid configuration: client_max_body_size '" +
 			tokens.at(i) + "'");
 	}
-	if (size < 0 || ConfFile::MAX_BODY_SIZE < size)
+	if (size < 0 || ConfFile::LIMIT_CLIENT_MAX_BODY_SIZE < size)
 		throw ConfigException(
 			"[emerg] Invalid configuration: client_max_body_size '" +
 			tokens.at(i) + "'");

--- a/src/config/ConfigParser.cpp
+++ b/src/config/ConfigParser.cpp
@@ -55,11 +55,37 @@ void ConfigParser::parseListen(const std::vector<std::string>& tokens,
 	char* end = NULL;
 	long  port = std::strtol(tokens.at(i).c_str(), &end, 10);
 	if (*end != 0)
-		throw ConfigException("[emerg] Invalid configuration: Listen '" +
+		throw ConfigException("[emerg] Invalid configuration: listen '" +
 							  tokens.at(i) + "'");
 	else if (port < 0 || 65535 < port)
 		throw ConfigException("[emerg] Invalid configuration: port range");
 	config.setListen(port);
+	expectToken(tokens, ++i, ";");
+}
+
+void ConfigParser::parseClientMaxBodySize(
+	const std::vector<std::string>& tokens, Config& config, unsigned long& i) {
+	char*	  end = NULL;
+	long long size = std::strtoll(tokens.at(i).c_str(), &end, 10);
+
+	std::string unit(end);
+	for (unsigned long i = 0; i < unit.size(); i++) unit[i] = tolower(unit[i]);
+	if (unit == "k" || unit == "kb") {
+		size *= 1024;
+	} else if (unit == "m" || unit == "mb") {
+		size *= 1024 * 1024;
+	} else if (unit == "g" || unit == "gb") {
+		size *= 1024 * 1024 * 1024;
+	} else if (!unit.empty()) {
+		throw ConfigException(
+			"[emerg] Invalid configuration: client_max_body_size '" +
+			tokens.at(i) + "'");
+	}
+	if (size < 0 || ConfFile::MAX_ALLOWABLE_SIZE < size)
+		throw ConfigException(
+			"[emerg] Invalid configuration: client_max_body_size '" +
+			tokens.at(i) + "'");
+	config.setClientMaxBodySize(size);
 	expectToken(tokens, ++i, ";");
 }
 
@@ -147,6 +173,8 @@ Config ConfigParser::parseServer(const std::vector<std::string>& tokens,
 	while (tokens.at(++i) != "}") {
 		if (tokens.at(i) == "listen")
 			parseListen(tokens, config, ++i);
+		else if (tokens.at(i) == "client_max_body_size")
+			parseClientMaxBodySize(tokens, config, ++i);
 		else if (tokens.at(i) == "autoindex")
 			parseAutoIndex(tokens, config, ++i);
 		else if (tokens.at(i) == "server_name")

--- a/src/config/ConfigParser.cpp
+++ b/src/config/ConfigParser.cpp
@@ -81,7 +81,7 @@ void ConfigParser::parseClientMaxBodySize(
 			"[emerg] Invalid configuration: client_max_body_size '" +
 			tokens.at(i) + "'");
 	}
-	if (size < 0 || ConfFile::MAX_ALLOWABLE_SIZE < size)
+	if (size < 0 || ConfFile::MAX_BODY_SIZE < size)
 		throw ConfigException(
 			"[emerg] Invalid configuration: client_max_body_size '" +
 			tokens.at(i) + "'");

--- a/src/config/ConfigParser.hpp
+++ b/src/config/ConfigParser.hpp
@@ -25,6 +25,8 @@ class ConfigParser {
 							unsigned long&);
 		void parseListen(const std::vector<std::string>&, Config&,
 						 unsigned long&);
+		void parseClientMaxBodySize(const std::vector<std::string>&, Config&,
+									unsigned long&);
 		void parseServerName(const std::vector<std::string>&, Config&,
 							 unsigned long&);
 		void parseIndex(const std::vector<std::string>&, Config&,

--- a/src/config/model/Config.cpp
+++ b/src/config/model/Config.cpp
@@ -1,12 +1,13 @@
 #include "Config.hpp"
 
-Config::Config() : _auto_index(false), _listen(-1), _server_name("_"), _index("index.html") {}
+Config::Config() : _auto_index(false), _listen(-1), _client_max_body_size(1024 * 1024), _server_name("_"), _index("index.html") {}
 
 Config::Config(const Config& other) { *this = other; }
 
 Config& Config::operator=(const Config& other) {
 	_auto_index = other._auto_index;
 	_listen = other._listen;
+	_client_max_body_size = other._client_max_body_size;
 	_server_name = other._server_name;
 	_index = other._index;
 	_root = other._root;
@@ -17,6 +18,8 @@ Config& Config::operator=(const Config& other) {
 bool Config::getAutoIndex() const { return _auto_index; }
 
 int Config::getListen() const { return _listen; }
+
+int Config::getClientMaxBodySize() const { return _client_max_body_size; }
 
 const std::string& Config::getServerName() const { return _server_name; }
 
@@ -31,6 +34,10 @@ const std::map<std::string, ConfigLocation>& Config::getLocation() const {
 void Config::setAutoIndex(bool auto_index) { _auto_index = auto_index; }
 
 void Config::setListen(int listen) { _listen = listen; }
+
+void Config::setClientMaxBodySize(int client_max_body_size) {
+	_client_max_body_size = client_max_body_size;
+}
 
 void Config::setServerName(const std::string& serverName) {
 	_server_name = serverName;

--- a/src/config/model/Config.cpp
+++ b/src/config/model/Config.cpp
@@ -1,6 +1,11 @@
 #include "Config.hpp"
 
-Config::Config() : _auto_index(false), _listen(-1), _client_max_body_size(1024 * 1024), _server_name("_"), _index("index.html") {}
+Config::Config()
+	: _auto_index(false),
+	  _listen(-1),
+	  _client_max_body_size(1024 * 1024),
+	  _server_name("_"),
+	  _index("index.html") {}
 
 Config::Config(const Config& other) { *this = other; }
 
@@ -19,7 +24,7 @@ bool Config::getAutoIndex() const { return _auto_index; }
 
 int Config::getListen() const { return _listen; }
 
-int Config::getClientMaxBodySize() const { return _client_max_body_size; }
+long long Config::getClientMaxBodySize() const { return _client_max_body_size; }
 
 const std::string& Config::getServerName() const { return _server_name; }
 
@@ -35,7 +40,7 @@ void Config::setAutoIndex(bool auto_index) { _auto_index = auto_index; }
 
 void Config::setListen(int listen) { _listen = listen; }
 
-void Config::setClientMaxBodySize(int client_max_body_size) {
+void Config::setClientMaxBodySize(long long client_max_body_size) {
 	_client_max_body_size = client_max_body_size;
 }
 

--- a/src/config/model/Config.cpp
+++ b/src/config/model/Config.cpp
@@ -3,7 +3,7 @@
 Config::Config()
 	: _auto_index(false),
 	  _listen(-1),
-	  _client_max_body_size(1024 * 1024),
+	  _client_max_body_size(ConfFile::DEFAULT_CLIENT_MAX_BODY_SIZE),
 	  _server_name("_"),
 	  _index("index.html") {}
 

--- a/src/config/model/Config.cpp
+++ b/src/config/model/Config.cpp
@@ -4,8 +4,8 @@ Config::Config()
 	: _auto_index(false),
 	  _listen(-1),
 	  _client_max_body_size(ConfFile::DEFAULT_CLIENT_MAX_BODY_SIZE),
-	  _server_name("_"),
-	  _index("index.html") {}
+	  _server_name(ConfFile::DEFAULT_SERVER_NAME()),
+	  _index(ConfFile::DEFAULT_INDEX()) {}
 
 Config::Config(const Config& other) { *this = other; }
 

--- a/src/config/model/Config.hpp
+++ b/src/config/model/Config.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "../exception/ConfigException.hpp"
+#include "../types/ConfFile.hpp"
 
 struct ConfigLocation {
 		std::string				 _root;
@@ -17,7 +18,7 @@ class Config {
 	private:
 		bool								  _auto_index;
 		int									  _listen;
-		long long								  _client_max_body_size;
+		long long							  _client_max_body_size;
 		std::string							  _server_name;
 		std::string							  _index;
 		std::string							  _root;
@@ -30,12 +31,12 @@ class Config {
 		~Config() {}
 
 		// getter
-		bool										 getAutoIndex() const;
-		int											 getListen() const;
-		long long									 getClientMaxBodySize() const;
-		const std::string&							 getServerName() const;
-		const std::string&							 getIndex() const;
-		const std::string&							 getRoot() const;
+		bool			   getAutoIndex() const;
+		int				   getListen() const;
+		long long		   getClientMaxBodySize() const;
+		const std::string& getServerName() const;
+		const std::string& getIndex() const;
+		const std::string& getRoot() const;
 		const std::map<std::string, ConfigLocation>& getLocation() const;
 		const std::string& getLocationRoot(const std::string&) const;
 		const std::string& getLocationIndex(const std::string&) const;

--- a/src/config/model/Config.hpp
+++ b/src/config/model/Config.hpp
@@ -17,6 +17,7 @@ class Config {
 	private:
 		bool								  _auto_index;
 		int									  _listen;
+		int									  _client_max_body_size;
 		std::string							  _server_name;
 		std::string							  _index;
 		std::string							  _root;
@@ -31,6 +32,7 @@ class Config {
 		// getter
 		bool										 getAutoIndex() const;
 		int											 getListen() const;
+		int											 getClientMaxBodySize() const;
 		const std::string&							 getServerName() const;
 		const std::string&							 getIndex() const;
 		const std::string&							 getRoot() const;
@@ -43,6 +45,7 @@ class Config {
 		// setter
 		void setAutoIndex(bool);
 		void setListen(int);
+		void setClientMaxBodySize(int);
 		void setServerName(const std::string&);
 		void setIndex(const std::string&);
 		void setRoot(const std::string&);

--- a/src/config/model/Config.hpp
+++ b/src/config/model/Config.hpp
@@ -17,7 +17,7 @@ class Config {
 	private:
 		bool								  _auto_index;
 		int									  _listen;
-		int									  _client_max_body_size;
+		long long								  _client_max_body_size;
 		std::string							  _server_name;
 		std::string							  _index;
 		std::string							  _root;
@@ -32,7 +32,7 @@ class Config {
 		// getter
 		bool										 getAutoIndex() const;
 		int											 getListen() const;
-		int											 getClientMaxBodySize() const;
+		long long									 getClientMaxBodySize() const;
 		const std::string&							 getServerName() const;
 		const std::string&							 getIndex() const;
 		const std::string&							 getRoot() const;
@@ -45,7 +45,7 @@ class Config {
 		// setter
 		void setAutoIndex(bool);
 		void setListen(int);
-		void setClientMaxBodySize(int);
+		void setClientMaxBodySize(long long);
 		void setServerName(const std::string&);
 		void setIndex(const std::string&);
 		void setRoot(const std::string&);

--- a/src/config/types/ConfFile.hpp
+++ b/src/config/types/ConfFile.hpp
@@ -4,7 +4,8 @@
 
 namespace ConfFile {
 	inline const char* DEFAULT_PATH() { return "default.conf"; }
-	static const long long MAX_ALLOWABLE_SIZE = 2LL * 1024 * 1024 * 1024; // 2GB
+	static const long long DEFAULT_CLIENT_MAX_BODY_SIZE = 1024 * 1024;
+	static const long long CLIENT_BODY_SIZE_LIMIT = 2LL * 1024 * 1024 * 1024; // 2GB
 }
 
 #endif

--- a/src/config/types/ConfFile.hpp
+++ b/src/config/types/ConfFile.hpp
@@ -4,8 +4,10 @@
 
 namespace ConfFile {
 	inline const char* DEFAULT_PATH() { return "default.conf"; }
+	inline const char* DEFAULT_SERVER_NAME() { return "_"; }
+	inline const char* DEFAULT_INDEX() { return "index.html"; }
 	static const long long DEFAULT_CLIENT_MAX_BODY_SIZE = 1024 * 1024;
-	static const long long CLIENT_BODY_SIZE_LIMIT = 2LL * 1024 * 1024 * 1024; // 2GB
+	static const long long LIMIT_CLIENT_MAX_BODY_SIZE = 2LL * 1024 * 1024 * 1024; // 2GB
 }
 
 #endif

--- a/src/config/types/ConfFile.hpp
+++ b/src/config/types/ConfFile.hpp
@@ -4,6 +4,7 @@
 
 namespace ConfFile {
 	inline const char* DEFAULT_PATH() { return "default.conf"; }
+	static const long long MAX_ALLOWABLE_SIZE = 2LL * 1024 * 1024 * 1024; // 2GB
 }
 
 #endif


### PR DESCRIPTION
## 📌 PR 제목

<!-- ex: feat: 게시글 작성 기능 구현 -->

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 변경 내용

- conf 파일 중 client_max_body_size 파싱 부분을 구현
- 각 server 내 동일한 client_max_body_size 지원
- 빠른 구현 필요한 부분

예:

- 게시글 작성 API 구현
- 입력값 유효성 검사 로직 추가
- swagger 문서 추가

## ✅ 확인 사항

- [ ] 기능 동작 확인
- [ ] 기존 테스트 통과
- [ ] Swagger 문서 확인 (필요 시)
- [ ] 코드 컨벤션 준수

## 📸스크린샷 (선택)

## 📎 관련 이슈 (선택)

<!-- 예: closes #12 -->
