### PR TITLE
hotfix: explicit 키워드 추가

### DIFF
--- a/src/handler/exception/Exception.hpp
+++ b/src/handler/exception/Exception.hpp
@@ -12,7 +12,7 @@ namespace handler {
 
 		public:
 			Exception() {}
-			Exception(const std::string& message) : _message(message) {}
+			explicit Exception(const std::string& message) : _message(message) {}
 			virtual ~Exception() throw() {}
 
 			virtual const char* what() const throw() {


### PR DESCRIPTION
`handler::Exception` -> `explicit` 키워드 추가