### PR TITLE
Feat/connection header

### DIFF
--- a/src/config/parser/Parser.cpp
+++ b/src/config/parser/Parser.cpp
@@ -2,6 +2,7 @@
 #include "Parser.hpp"
 
 #include <cctype>
+#include <cstdlib>
 #include <stdexcept>
 
 #include "../../utils/file_utils.hpp"

--- a/src/handler/EventHandler.cpp
+++ b/src/handler/EventHandler.cpp
@@ -149,7 +149,7 @@ EventResult EventHandler::handleClientEvent(int fd, uint32_t events, const confi
 		break;
 	}
 
-	if (disconnected) result.closeFd = fd;
+	if (disconnected) result.reset(fd);
 	return result;
 }
 

--- a/src/handler/EventHandler.hpp
+++ b/src/handler/EventHandler.hpp
@@ -39,7 +39,13 @@ namespace handler {
 			RequestHandler _requestHandler;
 			cgi::ProcessManager _cgiProcessManager;
 			std::map<int, http::Parser*> _parsers;
-			std::map<int, const config::Config*> _cgiClientConfigs;
+			struct CgiContext {
+					const config::Config* config;
+					bool keepAlive;
+					CgiContext() : config(NULL), keepAlive(false) {}
+					CgiContext(const config::Config* cfg, bool ka) : config(cfg), keepAlive(ka) {}
+			};
+			std::map<int, CgiContext> _cgiContexts;
 
 			http::Parser* ensureParser(int, const config::Config*);
 			std::string readSocket(int) const;

--- a/src/handler/EventHandler.hpp
+++ b/src/handler/EventHandler.hpp
@@ -2,7 +2,8 @@
 #ifndef HANDLER_EVENTHANDLER_HPP
 #define HANDLER_EVENTHANDLER_HPP
 
-#include <cstdint>
+#include <stdint.h>
+
 #include <map>
 #include <string>
 

--- a/src/handler/EventHandler.hpp
+++ b/src/handler/EventHandler.hpp
@@ -8,11 +8,11 @@
 #include <string>
 
 #include "../config/model/Config.hpp"
-#include "../http/model/Packet.hpp"
 #include "../http/parser/Parser.hpp"
 #include "../router/Router.hpp"
 #include "RequestHandler.hpp"
 #include "cgi/ProcessManager.hpp"
+#include "model/EventResult.hpp"
 
 namespace server {
 	class EpollManager;
@@ -20,57 +20,6 @@ namespace server {
 
 namespace handler {
 	class EventHandler {
-		public:
-			struct Result {
-					int fd;
-					http::Packet* packet;
-					std::string raw;
-					bool useRaw;
-					bool keepAlive;
-					bool closeAfterSend;
-					int closeFd;
-					Result() :
-						fd(-1),
-						packet(NULL),
-						raw(),
-						useRaw(false),
-						keepAlive(false),
-						closeAfterSend(false),
-						closeFd(-1) {}
-					Result(const Result& other) :
-						fd(other.fd),
-						packet(other.packet ? new http::Packet(*other.packet) : NULL),
-						raw(other.raw),
-						useRaw(other.useRaw),
-						keepAlive(other.keepAlive),
-						closeAfterSend(other.closeAfterSend),
-						closeFd(other.closeFd) {}
-					Result& operator=(const Result& other) {
-						if (this != &other) {
-							fd = other.fd;
-							raw = other.raw;
-							useRaw = other.useRaw;
-							keepAlive = other.keepAlive;
-							closeAfterSend = other.closeAfterSend;
-							closeFd = other.closeFd;
-							delete packet;
-							packet = other.packet ? new http::Packet(*other.packet) : NULL;
-						}
-						return *this;
-					}
-					~Result() {
-						delete packet;
-					}
-					void setPacket(const http::Packet& value) {
-						delete packet;
-						packet = new http::Packet(value);
-					}
-					void clearPacket() {
-						delete packet;
-						packet = NULL;
-					}
-			};
-
 		private:
 			router::Router _router;
 			RequestHandler _requestHandler;
@@ -86,14 +35,15 @@ namespace handler {
 
 			http::Parser* ensureParser(int, const config::Config*);
 			std::string readSocket(int) const;
-			Result handleClientEvent(int, uint32_t, const config::Config*, server::EpollManager&);
-			Result handleCgiEvent(int, uint32_t, const config::Config*, server::EpollManager&);
+			EventResult handleClientEvent(int, uint32_t, const config::Config*,
+										  server::EpollManager&);
+			EventResult handleCgiEvent(int, uint32_t, const config::Config*, server::EpollManager&);
 
 		public:
 			EventHandler();
 			~EventHandler();
 
-			Result handleEvent(int, uint32_t, const config::Config*, server::EpollManager&);
+			EventResult handleEvent(int, uint32_t, const config::Config*, server::EpollManager&);
 			void cleanup(int, server::EpollManager&);
 	};
 }  // namespace handler

--- a/src/handler/EventHandler.hpp
+++ b/src/handler/EventHandler.hpp
@@ -34,7 +34,7 @@ namespace handler {
 			std::map<int, CgiContext> _cgiContexts;
 
 			http::Parser* ensureParser(int, const config::Config*);
-			std::string readSocket(int) const;
+			std::string readSocket(int, bool&) const;
 			EventResult handleClientEvent(int, uint32_t, const config::Config*,
 										  server::EpollManager&);
 			EventResult handleCgiEvent(int, uint32_t, const config::Config*, server::EpollManager&);

--- a/src/handler/cgi/Executor.cpp
+++ b/src/handler/cgi/Executor.cpp
@@ -92,6 +92,6 @@ void Executor::execute(const router::RouteDecision& decision, const http::Packet
 			bodyPayload.assign(reinterpret_cast<const char*>(bodyData.data()), bodyData.size());
 	}
 
-	cgiManager.registerProcess(pid, stdoutPair[0], stdinPair[0], clientFd, bodyPayload,
-							   epollManager);
+	cgiManager.registerCgiProcess(pid, stdoutPair[0], stdinPair[0], clientFd, bodyPayload,
+								  epollManager);
 }

--- a/src/handler/cgi/Executor.cpp
+++ b/src/handler/cgi/Executor.cpp
@@ -3,6 +3,8 @@
 
 #include <sys/socket.h>
 
+#include <cstdlib>
+
 #include "../../utils/str_utils.hpp"
 
 using namespace handler::cgi;

--- a/src/handler/cgi/ProcessManager.cpp
+++ b/src/handler/cgi/ProcessManager.cpp
@@ -112,8 +112,9 @@ void ProcessManager::handleCgiEvent(int fd, uint32_t events, server::EpollManage
 	if (events & EPOLLOUT) trySendPendingInput(procIt->second, epollManager);
 }
 
-void ProcessManager::registerProcess(pid_t pid, int stdoutFd, int stdinFd, int clientFd,
-									 const std::string& body, server::EpollManager& epollManager) {
+void ProcessManager::registerCgiProcess(pid_t pid, int stdoutFd, int stdinFd, int clientFd,
+										const std::string& body,
+										server::EpollManager& epollManager) {
 	Process process(pid, stdoutFd, stdinFd, clientFd, body);
 	_processes[stdoutFd] = process;
 	_clientToStdout[clientFd] = stdoutFd;
@@ -156,10 +157,7 @@ int ProcessManager::getClientFd(int fd) const {
 
 std::string ProcessManager::getResponse(int stdoutFd) {
 	std::map<int, Process>::iterator procIt = _processes.find(stdoutFd);
-	if (procIt == _processes.end()) throw handler::Exception();
-	std::string output = procIt->second.output;
-	if (output.empty()) throw handler::Exception();
-	return output;
+	return procIt->second.output;
 }
 
 bool ProcessManager::isCgiProcess(int fd) const {
@@ -177,4 +175,8 @@ bool ProcessManager::isCompleted(int clientFd) const {
 	std::map<int, Process>::const_iterator procIt = _processes.find(it->second);
 	if (procIt == _processes.end()) return false;
 	return procIt->second.completed;
+}
+
+bool ProcessManager::isStdout(int fd) const {
+	return _processes.find(fd) != _processes.end();
 }

--- a/src/handler/cgi/ProcessManager.cpp
+++ b/src/handler/cgi/ProcessManager.cpp
@@ -14,13 +14,6 @@ namespace {
 	const unsigned int kStdinEvents = EPOLLOUT | EPOLLET;
 }
 
-void ProcessManager::sigchldHandler(int sig) {
-	(void) sig;
-	int status;
-	while (waitpid(-1, &status, WNOHANG) > 0) {
-	}
-}
-
 void ProcessManager::closeFdQuiet(int fd) {
 	if (fd >= 0) close(fd);
 }

--- a/src/handler/cgi/ProcessManager.hpp
+++ b/src/handler/cgi/ProcessManager.hpp
@@ -68,8 +68,6 @@ namespace handler {
 				ProcessManager() {}
 				~ProcessManager() {}
 
-				static void sigchldHandler(int);
-
 				void handleCgiEvent(int, uint32_t, server::EpollManager&);
 				void registerProcess(pid_t, int, int, int, const std::string&,
 									 server::EpollManager&);

--- a/src/handler/cgi/ProcessManager.hpp
+++ b/src/handler/cgi/ProcessManager.hpp
@@ -69,14 +69,15 @@ namespace handler {
 				~ProcessManager() {}
 
 				void handleCgiEvent(int, uint32_t, server::EpollManager&);
-				void registerProcess(pid_t, int, int, int, const std::string&,
-									 server::EpollManager&);
+				void registerCgiProcess(pid_t, int, int, int, const std::string&,
+										server::EpollManager&);
 				void removeCgiProcess(int, server::EpollManager&);
 				int getClientFd(int) const;
 				std::string getResponse(int);
 				bool isCgiProcess(int) const;
 				bool isProcessing(int) const;
 				bool isCompleted(int) const;
+				bool isStdout(int) const;
 		};
 	}  // namespace cgi
 }  // namespace handler

--- a/src/handler/cgi/Responder.cpp
+++ b/src/handler/cgi/Responder.cpp
@@ -42,7 +42,7 @@ Responder::CgiOutput Responder::parseCgiOutput(const std::string& cgiResult) {
 	return output;
 }
 
-std::string Responder::makeCgiResponse(const std::string& cgiResult) {
+std::string Responder::makeCgiResponse(const std::string& cgiResult, bool keepAlive) {
 	CgiOutput cgiOutput = Responder::parseCgiOutput(cgiResult);
 	std::string httpHeader = cgiOutput.httpHeader;
 	std::string body = cgiOutput.body;
@@ -63,7 +63,9 @@ std::string Responder::makeCgiResponse(const std::string& cgiResult) {
 		 "Content-Length: " +
 		 int_tostr(body.size()) +
 		 "\r\n"
-		 "Server: webserv\r\n");
+		 "Server: webserv\r\n"
+		 "Connection: " +
+		 std::string(keepAlive ? "keep-alive" : "close") + "\r\n");
 
 	return statusLine + httpHeader + "\r\n" + body;
 }

--- a/src/handler/cgi/Responder.hpp
+++ b/src/handler/cgi/Responder.hpp
@@ -32,7 +32,7 @@ namespace handler {
 				static CgiOutput parseCgiOutput(const std::string& cgiResult);
 
 			public:
-				static std::string makeCgiResponse(const std::string&);
+				static std::string makeCgiResponse(const std::string&, bool keepAlive);
 		};
 	}  // namespace cgi
 }  // namespace handler

--- a/src/handler/cgi/Responder.hpp
+++ b/src/handler/cgi/Responder.hpp
@@ -5,8 +5,6 @@
 #include <string>
 
 #include "../../http/Enums.hpp"
-#include "../../utils/str_utils.hpp"
-#include "../exception/Exception.hpp"
 
 namespace handler {
 	namespace cgi {
@@ -16,6 +14,7 @@ namespace handler {
 						std::string httpHeader;
 						std::string body;
 						http::StatusCode::Value statusCode;
+						std::string reasonPhrase;
 						enum error {
 							NONE,
 							INVALID_FORMAT,
@@ -24,6 +23,7 @@ namespace handler {
 							httpHeader(""),
 							body(""),
 							statusCode(http::StatusCode::UnknownStatus),
+							reasonPhrase(""),
 							error(NONE) {}
 				};
 

--- a/src/handler/model/EventResult.cpp
+++ b/src/handler/model/EventResult.cpp
@@ -1,0 +1,76 @@
+#include "EventResult.hpp"
+
+#include <cstddef>
+
+using namespace handler;
+
+void EventResult::copyFrom(const EventResult& other) {
+	fd = other.fd;
+	raw = other.raw;
+	useRaw = other.useRaw;
+	keepAlive = other.keepAlive;
+	closeAfterSend = other.closeAfterSend;
+	closeFd = other.closeFd;
+	delete packet;
+	packet = other.packet ? new http::Packet(*other.packet) : NULL;
+}
+
+EventResult::EventResult() :
+	fd(-1),
+	packet(NULL),
+	raw(),
+	useRaw(false),
+	keepAlive(false),
+	closeAfterSend(false),
+	closeFd(-1) {}
+
+EventResult::EventResult(const EventResult& other) : fd(-1), packet(NULL) {
+	copyFrom(other);
+}
+
+EventResult& EventResult::operator=(const EventResult& other) {
+	if (this != &other) copyFrom(other);
+	return *this;
+}
+
+EventResult::~EventResult() {
+	delete packet;
+}
+
+void EventResult::setPacket(const http::Packet& value) {
+	delete packet;
+	packet = new http::Packet(value);
+}
+
+void EventResult::clearPacket() {
+	delete packet;
+	packet = NULL;
+}
+
+void EventResult::setPacketResponse(int socketFd, const http::Packet& value, bool keep) {
+	fd = socketFd;
+	setPacket(value);
+	raw.clear();
+	useRaw = false;
+	keepAlive = keep;
+	closeAfterSend = !keep;
+}
+
+void EventResult::setRawResponse(int socketFd, const std::string& value, bool keep) {
+	fd = socketFd;
+	clearPacket();
+	raw = value;
+	useRaw = true;
+	keepAlive = keep;
+	closeAfterSend = !keep;
+}
+
+void EventResult::reset() {
+	fd = -1;
+	clearPacket();
+	raw.clear();
+	useRaw = false;
+	keepAlive = false;
+	closeAfterSend = false;
+	closeFd = -1;
+}

--- a/src/handler/model/EventResult.cpp
+++ b/src/handler/model/EventResult.cpp
@@ -65,12 +65,12 @@ void EventResult::setRawResponse(int socketFd, const std::string& value, bool ke
 	closeAfterSend = !keep;
 }
 
-void EventResult::reset() {
-	fd = -1;
+void EventResult::reset(int fd = -1) {
+	this->fd = -1;
 	clearPacket();
 	raw.clear();
 	useRaw = false;
 	keepAlive = false;
 	closeAfterSend = false;
-	closeFd = -1;
+	closeFd = fd;
 }

--- a/src/handler/model/EventResult.hpp
+++ b/src/handler/model/EventResult.hpp
@@ -1,0 +1,35 @@
+#ifndef HANDLER_EVENTRESULT_HPP
+#define HANDLER_EVENTRESULT_HPP
+
+#include <string>
+
+#include "../../http/model/Packet.hpp"
+
+namespace handler {
+	class EventResult {
+		private:
+			void copyFrom(const EventResult&);
+
+		public:
+			int fd;
+			http::Packet* packet;
+			std::string raw;
+			bool useRaw;
+			bool keepAlive;
+			bool closeAfterSend;
+			int closeFd;
+
+			EventResult();
+			EventResult(const EventResult&);
+			EventResult& operator=(const EventResult&);
+			~EventResult();
+
+			void setPacket(const http::Packet&);
+			void clearPacket();
+			void setPacketResponse(int, const http::Packet&, bool);
+			void setRawResponse(int, const std::string&, bool);
+			void reset();
+	};
+}  // namespace handler
+
+#endif

--- a/src/handler/model/EventResult.hpp
+++ b/src/handler/model/EventResult.hpp
@@ -28,7 +28,7 @@ namespace handler {
 			void clearPacket();
 			void setPacketResponse(int, const http::Packet&, bool);
 			void setRawResponse(int, const std::string&, bool);
-			void reset();
+			void reset(int);
 	};
 }  // namespace handler
 

--- a/src/handler/model/EventResult.hpp
+++ b/src/handler/model/EventResult.hpp
@@ -9,6 +9,8 @@ namespace handler {
 	class EventResult {
 		private:
 			void copyFrom(const EventResult&);
+			void setPacket(const http::Packet&);
+			void clearPacket();
 
 		public:
 			int fd;
@@ -24,8 +26,6 @@ namespace handler {
 			EventResult& operator=(const EventResult&);
 			~EventResult();
 
-			void setPacket(const http::Packet&);
-			void clearPacket();
 			void setPacketResponse(int, const http::Packet&, bool);
 			void setRawResponse(int, const std::string&, bool);
 			void reset(int);

--- a/src/handler/utils/response.hpp
+++ b/src/handler/utils/response.hpp
@@ -76,8 +76,9 @@ namespace handler {
 			} else if (contentType.empty())
 				contentType = "text/html";
 
-			http::Packet response({"HTTP/1.1", status, http::StatusCode::to_reasonPhrase(status)},
-								  http::Header(), http::Body());
+			http::StatusLine statusLine = {"HTTP/1.1", status,
+										   http::StatusCode::to_reasonPhrase(status)};
+			http::Packet response(statusLine, http::Header(), http::Body());
 			if (!contentType.empty()) response.addHeader("Content-Type", contentType);
 			if (!body.empty()) response.appendBody(body.c_str(), body.size());
 			return response;

--- a/src/http/serializer/Serializer.hpp
+++ b/src/http/serializer/Serializer.hpp
@@ -9,7 +9,7 @@
 namespace http {
 	class Serializer {
 		public:
-			static std::string serialize(const Packet&);
+			static std::string serialize(const Packet&, bool keepAlive);
 	};
 }  // namespace http
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,5 @@ int main(int argc, char* argv[]) {
 	} catch (const std::exception& e) {
 		std::cerr << e.what() << '\n';
 	}
-
 	return 0;
 }

--- a/src/router/utils/mime.cpp
+++ b/src/router/utils/mime.cpp
@@ -3,23 +3,33 @@
 
 #include <map>
 
+namespace {
+	std::map<std::string, std::string> initMimeMap() {
+		std::map<std::string, std::string> m;
+		m[".html"] = "text/html";
+		m[".txt"] = "text/plain";
+		m[".css"] = "text/css";
+		m[".js"] = "application/javascript";
+		m[".json"] = "application/json";
+		m[".png"] = "image/png";
+		m[".jpg"] = "image/jpeg";
+		return m;
+	}
+
+	const std::map<std::string, std::string> g_mimeMap = initMimeMap();
+}
+
 namespace router {
 	namespace utils {
 		std::string byExtension(const std::string& filename) {
-			static const std::map<std::string, std::string> kMap = {
-				{".html", "text/html"},		   {".txt", "text/plain"},
-				{".css", "text/css"},		   {".js", "application/javascript"},
-				{".json", "application/json"}, {".png", "image/png"},
-				{".jpg", "image/jpeg"},
-			};
 			size_t dot = filename.find_last_of('.');
 			if (dot == std::string::npos) return "application/octet-stream";
 
 			std::string ext = filename.substr(dot);
-			std::map<std::string, std::string>::const_iterator it = kMap.find(ext);
-			if (it != kMap.end()) return it->second;
+			std::map<std::string, std::string>::const_iterator it = g_mimeMap.find(ext);
+			if (it != g_mimeMap.end()) return it->second;
 
 			return "application/octet-stream";
 		}
-	}  // namespace utils
+	}
 }  // namespace router

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <iostream>
 
+#include "../handler/model/EventResult.hpp"
 #include "../http/serializer/Serializer.hpp"
 #include "Signal.hpp"
 #include "epoll/exception/EpollException.hpp"
@@ -71,7 +72,7 @@ void Server::handleEvents() {
 		if (getsockname(eventFd, reinterpret_cast<sockaddr*>(&addr), &len) == 0)
 			localPort = ntohs(addr.sin_port);
 
-		EventHandler::Result result =
+		EventResult result =
 			_eventHandler.handleEvent(eventFd, event.events, findConfig(localPort), _epollManager);
 
 		if (result.fd != -1) {

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -89,7 +89,7 @@ void Server::handleEvents() {
 			}
 		}
 
-		if (result.closeFd != -1 && (result.closeFd != result.fd || !result.closeAfterSend)) {
+		if (result.closeFd != -1 && (result.closeFd != result.fd)) {
 			_eventHandler.cleanup(result.closeFd, _epollManager);
 			_epollManager.remove(result.closeFd);
 		}

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 
 #include "../http/serializer/Serializer.hpp"
+#include "Signal.hpp"
 #include "epoll/exception/EpollException.hpp"
 #include "exception/Exception.hpp"
 #include "wrapper/SocketWrapper.hpp"
@@ -105,14 +106,8 @@ void Server::sendResponse(int socketFd, const std::string& rawResponse) {
 }
 
 void Server::run() {
-	struct sigaction sa;
-
-	sa.sa_handler = cgi::ProcessManager::sigchldHandler;
-	sigemptyset(&sa.sa_mask);
-	sa.sa_flags = SA_RESTART | SA_NOCLDSTOP;
-	if (sigaction(SIGCHLD, &sa, NULL) == -1) throw Exception("sigaction failed");
+	signalInstall();
 	_epollManager.init();
-
 	for (std::map<int, config::Config>::iterator it = _configs.begin(); it != _configs.end();
 		 ++it) {
 		initServer(it->first);

--- a/src/server/Server.hpp
+++ b/src/server/Server.hpp
@@ -34,7 +34,7 @@ namespace server {
 			void initServer(int);
 			void loop();
 			void handleEvents();
-			void sendResponse(int, const http::Packet&);
+			void sendResponse(int, const http::Packet&, bool);
 			void sendResponse(int, const std::string&);
 
 		public:

--- a/src/server/Signal.hpp
+++ b/src/server/Signal.hpp
@@ -1,0 +1,35 @@
+#ifndef SERVER_SIGNAL_SIGNALHANDLER_HPP
+#define SERVER_SIGNAL_SIGNALHANDLER_HPP
+
+#include <signal.h>
+
+#include "../handler/cgi/ProcessManager.hpp"
+#include "exception/Exception.hpp"
+
+namespace {
+	void sigchldHandler(int) {
+		int status;
+		while (waitpid(-1, &status, WNOHANG) > 0) {
+		}
+	}
+}
+
+namespace server {
+	void signalInstall() {
+		struct sigaction sa;
+		sa.sa_handler = sigchldHandler;
+		sigemptyset(&sa.sa_mask);
+		sa.sa_flags = SA_RESTART | SA_NOCLDSTOP;
+		if (sigaction(SIGCHLD, &sa, NULL) == -1)
+			throw server::Exception("sigaction SIGCHLD failed");
+
+		sa.sa_handler = SIG_IGN;
+		sigemptyset(&sa.sa_mask);
+		sa.sa_flags = 0;
+		if (sigaction(SIGPIPE, &sa, NULL) == -1)
+			throw server::Exception("sigaction SIGPIPE failed");
+	}
+
+}
+
+#endif

--- a/src/server/epoll/manager/EpollManager.cpp
+++ b/src/server/epoll/manager/EpollManager.cpp
@@ -61,7 +61,7 @@ void EpollManager::add(int fd, unsigned int events) {
 void EpollManager::remove(int fd) {
 	if (_counter.deleteFd(fd)) {
 		if (epoll_ctl(_epollFd, EPOLL_CTL_DEL, fd, NULL) == -1) {
-			throw EpollException("ctl del");
+			if (errno != EBADF && errno != ENOENT) throw EpollException("ctl del");
 		}
 		close(fd);
 	}

--- a/src/server/epoll/manager/EpollManager.cpp
+++ b/src/server/epoll/manager/EpollManager.cpp
@@ -1,6 +1,8 @@
 // EpollManager.cpp
 #include "EpollManager.hpp"
 
+#include <errno.h>
+
 #include "../exception/EpollException.hpp"
 
 using namespace server;

--- a/src/utils/str_utils.cpp
+++ b/src/utils/str_utils.cpp
@@ -25,3 +25,10 @@ std::string to_lower(const std::string& str) {
 	std::transform(lower_str.begin(), lower_str.end(), lower_str.begin(), ::tolower);
 	return lower_str;
 }
+
+std::string trim(const std::string& value) {
+	size_t start = value.find_first_not_of(" \t");
+	if (start == std::string::npos) return std::string();
+	size_t end = value.find_last_not_of(" \t");
+	return value.substr(start, end - start + 1);
+}

--- a/src/utils/str_utils.hpp
+++ b/src/utils/str_utils.hpp
@@ -7,5 +7,6 @@
 std::string int_tostr(int);
 int str_toint(const std::string&);
 std::string to_lower(const std::string&);
+std::string trim(const std::string&);
 
 #endif


### PR DESCRIPTION
## 📌 PR 제목

feat: improve connection teardown handling & ensure connection header/signal stability

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 코드 리팩토링
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📝 변경 내용

###간단한 요약

- HTTP Connection 헤더/keep-alive 정책과 signal 처리
- 커넥션 종료 경로를 일관성 있게 변경 -> 장시간 부하에서도 서버가 안정적으로 동작 기대

### 핵심 변경

- Serializer·Server에서 Connection 헤더를 직접 관리 + EventHandler/Responder/ProcessManager를 정리 -> CGI/일반 응답 모두에서 keep-alive 판단이 통일되도록 리팩터링
- EventResult 모델과 EventHandler 로직을 분리해 CGI STDOUT·stdin 관리, response 세팅, half-close 감지(readSocket의 peerClosed 리턴) 등을 단순화
- signal 처리 코드를 `server::Signal` 단일 모듈로 모아 main 진입부에서 제거하고, SIGCHLD/SIGPIPE를 일괄 설치해 자식 프로세스 정리를 안정화
- epoll FD 제거 시 EBADF/ENOENT를 허용하고, closeFd와 send 대상이 다를 때만 추가 cleanup을 수행하도록 하여 중복 제거·crash를 방지
- EPOLL_SIZE를 증가해 감시할 수 있는 FD 수 증가 + BUFFER_SIZE 증가로 대용량 요청/응답을 읽을 때 read 루프 회수를 감소

## ✅ 확인 사항

- [x] 기능 동작 확인
- [x] 기존 테스트 통과
- [x] 코드 컨벤션 준수

## 📸스크린샷 (선택)

없음

## 📎 관련 이슈 (선택)

close #64
